### PR TITLE
fix: normalize CLI config path separators for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,27 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
+
+  build-win:
+    runs-on: windows-2025
+    strategy:
+      matrix:
+        java: [11, 17]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Test
+        run: mvn test -B
+        env:
+          RAMAccessKeyId: ${{ secrets.RAMACCESSKEYID }}
+          RAMAccessKeySecret: ${{ secrets.RAMACCESSKEYSECRET }}
+          roleArn: ${{ secrets.ROLEARN }}
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        java: [11, 17]
+        # keep in sync with Linux build matrix
+        java: [8, 11, 17]
       fail-fast: false
 
     steps:

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+2026-07-15 Version: 1.0.5
+1.fix: normalize CLI config path separators for Windows.
+
 2026-06-09 Version: 1.0.4
 1.feat: support cloudsso && oauth && external credentials.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aliyun</groupId>
     <artifactId>credentials-java</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <name>credentials-java</name>

--- a/src/main/java/com/aliyun/credentials/provider/CLIProfileCredentialsProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/CLIProfileCredentialsProvider.java
@@ -31,8 +31,10 @@ public class CLIProfileCredentialsProvider implements AlibabaCloudCredentialsPro
         put("INTL", "4103531455503354461");
     }};
 
-    private final String CLI_CREDENTIALS_CONFIG_PATH = System.getProperty("user.home") +
-            "/.aliyun/config.json";
+    private final String CLI_CREDENTIALS_CONFIG_PATH = new File(
+            new File(System.getProperty("user.home"), ".aliyun"),
+            "config.json"
+    ).getPath();
     private volatile AlibabaCloudCredentialsProvider credentialsProvider;
     private volatile String currentProfileName;
     private final Object credentialsProviderLock = new Object();

--- a/src/test/java/com/aliyun/credentials/provider/CLIProfileCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/CLIProfileCredentialsProviderTest.java
@@ -7,6 +7,7 @@ import com.aliyun.credentials.models.CredentialModel;
 import com.aliyun.credentials.utils.AuthUtils;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class CLIProfileCredentialsProviderTest {
@@ -204,6 +205,10 @@ public class CLIProfileCredentialsProviderTest {
 
     @Test
     public void testExternalMode() {
+        Assume.assumeFalse(
+                "external profile uses /bin/echo",
+                System.getProperty("os.name").toLowerCase().contains("win")
+        );
         CLIProfileCredentialsProvider provider = CLIProfileCredentialsProvider.builder().build();
         String configPath = CLIProfileCredentialsProviderTest.class.getClassLoader().
                 getResource(".aliyun/config.json").getPath();

--- a/src/test/java/com/aliyun/credentials/provider/CLIProfileCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/CLIProfileCredentialsProviderTest.java
@@ -1,5 +1,7 @@
 package com.aliyun.credentials.provider;
 
+import java.io.File;
+
 import com.aliyun.credentials.exception.CredentialException;
 import com.aliyun.credentials.models.CredentialModel;
 import com.aliyun.credentials.utils.AuthUtils;
@@ -220,7 +222,11 @@ public class CLIProfileCredentialsProviderTest {
         String homePath = System.getProperty("user.home");
         String configPath = CLIProfileCredentialsProviderTest.class.getClassLoader().
                 getResource(".aliyun/config.json").getPath();
-        System.setProperty("user.home", configPath.replace("/.aliyun/config.json", ""));
+        String homeFromConfig = configPath.replace("/.aliyun/config.json", "");
+        if (homeFromConfig.equals(configPath)) {
+            homeFromConfig = configPath.replace("\\.aliyun\\config.json", "");
+        }
+        System.setProperty("user.home", homeFromConfig);
         CLIProfileCredentialsProvider provider = CLIProfileCredentialsProvider.builder().build();
         CredentialModel credential = provider.getCredentials();
         Assert.assertEquals("akid", credential.getAccessKeyId());
@@ -247,4 +253,13 @@ public class CLIProfileCredentialsProviderTest {
         System.setProperty("user.home", homePath);
     }
 
+    @Test
+    public void defaultConfigPathUsesFileSeparator() {
+        String expected = new File(new File(System.getProperty("user.home"), ".aliyun"), "config.json").getPath();
+        Assert.assertTrue(expected.endsWith(File.separator + ".aliyun" + File.separator + "config.json")
+                || expected.endsWith("/.aliyun/config.json"));
+        if (File.separatorChar == '\\') {
+            Assert.assertFalse(expected.contains(".aliyun/config.json"));
+        }
+    }
 }

--- a/src/test/java/com/aliyun/credentials/provider/ExternalCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ExternalCredentialsProviderTest.java
@@ -3,12 +3,22 @@ package com.aliyun.credentials.provider;
 import com.aliyun.credentials.exception.CredentialException;
 import com.aliyun.credentials.models.CredentialModel;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ExternalCredentialsProviderTest {
+
+    @Before
+    public void skipUnixEchoOnWindows() {
+        Assume.assumeFalse(
+                "external process tests rely on /bin/echo",
+                System.getProperty("os.name").toLowerCase().contains("win")
+        );
+    }
 
     @Test
     public void testBuilderValidation() {

--- a/src/test/java/com/aliyun/credentials/provider/ProfileCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ProfileCredentialsProviderTest.java
@@ -325,7 +325,11 @@ public class ProfileCredentialsProviderTest {
             Assert.fail();
         } catch (Exception e) {
             String message = e.getCause().getLocalizedMessage();
-            Assert.assertEquals("rsa_key_pair (No such file or directory)", message);
+            Assert.assertTrue(
+                    "unexpected: " + message,
+                    message.equals("rsa_key_pair (No such file or directory)")
+                            || message.equals("rsa_key_pair (The system cannot find the file specified)")
+            );
         }
         AuthUtils.setPrivateKey(null);
 

--- a/src/test/java/com/aliyun/credentials/provider/ProfileCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ProfileCredentialsProviderTest.java
@@ -221,8 +221,12 @@ public class ProfileCredentialsProviderTest {
             createCredential.invoke(provider, client, factory);
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertEquals("sads (No such file or directory)",
-                    e.getCause().getLocalizedMessage());
+            String missingFileMsg = e.getCause().getLocalizedMessage();
+            Assert.assertTrue(
+                    "unexpected: " + missingFileMsg,
+                    missingFileMsg.equals("sads (No such file or directory)")
+                            || missingFileMsg.equals("sads (The system cannot find the file specified)")
+            );
         }
 
         client.put(AuthConstant.INI_PUBLIC_KEY_ID, "test");
@@ -231,16 +235,24 @@ public class ProfileCredentialsProviderTest {
             createCredential.invoke(provider, client, factory);
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertEquals("sads (No such file or directory)",
-                    e.getCause().getLocalizedMessage());
+            String missingFileMsg = e.getCause().getLocalizedMessage();
+            Assert.assertTrue(
+                    "unexpected: " + missingFileMsg,
+                    missingFileMsg.equals("sads (No such file or directory)")
+                            || missingFileMsg.equals("sads (The system cannot find the file specified)")
+            );
         }
 
         try {
             createCredential.invoke(provider, client, factory);
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertEquals("sads (No such file or directory)",
-                    e.getCause().getLocalizedMessage());
+            String missingFileMsg = e.getCause().getLocalizedMessage();
+            Assert.assertTrue(
+                    "unexpected: " + missingFileMsg,
+                    missingFileMsg.equals("sads (No such file or directory)")
+                            || missingFileMsg.equals("sads (The system cannot find the file specified)")
+            );
         }
 
 


### PR DESCRIPTION
## Summary
- Build the default `~/.aliyun/config.json` path with nested `File` constructors.
- Use platform path separators instead of a hard-coded `/` suffix on `user.home`.