### PR TITLE
fix: quote-aware External process_command parsing

### DIFF
--- a/src/main/java/com/aliyun/credentials/provider/ExternalCredentialsProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/ExternalCredentialsProvider.java
@@ -3,6 +3,7 @@ package com.aliyun.credentials.provider;
 import com.aliyun.credentials.exception.CredentialException;
 import com.aliyun.credentials.models.CredentialModel;
 import com.aliyun.credentials.utils.AuthConstant;
+import com.aliyun.credentials.utils.CommandLineUtils;
 import com.aliyun.credentials.utils.ProviderName;
 import com.aliyun.credentials.utils.StringUtils;
 import com.google.gson.Gson;
@@ -70,10 +71,7 @@ public class ExternalCredentialsProvider implements AlibabaCloudCredentialsProvi
     }
 
     CredentialModel getCredentialsInternal() {
-        String[] args = this.processCommand.trim().split("\\s+");
-        if (args.length == 0 || StringUtils.isEmpty(args[0])) {
-            throw new CredentialException("process_command is empty");
-        }
+        String[] args = CommandLineUtils.split(this.processCommand);
 
         ProcessBuilder processBuilder = new ProcessBuilder(args);
         try {

--- a/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
+++ b/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
@@ -2,19 +2,31 @@ package com.aliyun.credentials.utils;
 
 import com.aliyun.credentials.exception.CredentialException;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Split process_command into argv with quote support so paths containing spaces
  * (e.g. Windows "C:\\Program Files\\...") can be passed as a single argument.
- * Escape rules follow POSIX shlex semantics.
+ * <p>
+ * On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
+ * next char; inside double quotes, '\' only escapes '"', '\', '$', '`' and
+ * newline; inside single quotes, all characters are literal.
+ * <p>
+ * On Windows, '\' is a path separator and is treated as a literal (except
+ * '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
+ * their backslashes.
  */
 public final class CommandLineUtils {
     private CommandLineUtils() {
     }
 
     public static String[] split(String command) {
+        return split(command, File.separatorChar == '\\');
+    }
+
+    static String[] split(String command, boolean windows) {
         if (command == null || command.trim().isEmpty()) {
             throw new CredentialException("process_command is empty");
         }
@@ -44,7 +56,14 @@ public final class CommandLineUtils {
                 }
                 if (c == '\\' && i + 1 < chars.length) {
                     char next = chars[i + 1];
-                    if (next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n') {
+                    if (windows) {
+                        // On Windows only \" is an escape inside double quotes.
+                        if (next == '"') {
+                            current.append(next);
+                            i++;
+                            continue;
+                        }
+                    } else if (next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n') {
                         current.append(next);
                         i++;
                         continue;
@@ -54,6 +73,12 @@ public final class CommandLineUtils {
                 continue;
             }
             if (c == '\\') {
+                if (windows) {
+                    // Path separator — keep literal.
+                    hasToken = true;
+                    current.append(c);
+                    continue;
+                }
                 if (i + 1 >= chars.length) {
                     throw new CredentialException("invalid process_command: trailing backslash");
                 }

--- a/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
+++ b/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
@@ -23,6 +23,9 @@ public final class CommandLineUtils {
         StringBuilder current = new StringBuilder();
         boolean inSingle = false;
         boolean inDouble = false;
+        // Tracks that a token has started even if it is empty, so quoted empty
+        // arguments like `tool "" arg` keep their empty argv element.
+        boolean hasToken = false;
 
         for (int i = 0; i < chars.length; i++) {
             char c = chars[i];
@@ -54,31 +57,36 @@ public final class CommandLineUtils {
                 if (i + 1 >= chars.length) {
                     throw new CredentialException("invalid process_command: trailing backslash");
                 }
+                hasToken = true;
                 current.append(chars[++i]);
                 continue;
             }
             if (c == '\'') {
                 inSingle = true;
+                hasToken = true;
                 continue;
             }
             if (c == '"') {
                 inDouble = true;
+                hasToken = true;
                 continue;
             }
             if (Character.isWhitespace(c)) {
-                if (current.length() > 0) {
+                if (hasToken) {
                     args.add(current.toString());
                     current.setLength(0);
+                    hasToken = false;
                 }
                 continue;
             }
+            hasToken = true;
             current.append(c);
         }
 
         if (inSingle || inDouble) {
             throw new CredentialException("invalid process_command: unclosed quote");
         }
-        if (current.length() > 0) {
+        if (hasToken) {
             args.add(current.toString());
         }
         if (args.isEmpty() || StringUtils.isEmpty(args.get(0))) {

--- a/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
+++ b/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
@@ -1,0 +1,89 @@
+package com.aliyun.credentials.utils;
+
+import com.aliyun.credentials.exception.CredentialException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Split process_command into argv with quote support so paths containing spaces
+ * (e.g. Windows "C:\\Program Files\\...") can be passed as a single argument.
+ * Escape rules follow POSIX shlex semantics.
+ */
+public final class CommandLineUtils {
+    private CommandLineUtils() {
+    }
+
+    public static String[] split(String command) {
+        if (command == null || command.trim().isEmpty()) {
+            throw new CredentialException("process_command is empty");
+        }
+        char[] chars = command.trim().toCharArray();
+        List<String> args = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean inSingle = false;
+        boolean inDouble = false;
+
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
+            if (inSingle) {
+                if (c == '\'') {
+                    inSingle = false;
+                } else {
+                    current.append(c);
+                }
+                continue;
+            }
+            if (inDouble) {
+                if (c == '"') {
+                    inDouble = false;
+                    continue;
+                }
+                if (c == '\\' && i + 1 < chars.length) {
+                    char next = chars[i + 1];
+                    if (next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n') {
+                        current.append(next);
+                        i++;
+                        continue;
+                    }
+                }
+                current.append(c);
+                continue;
+            }
+            if (c == '\\') {
+                if (i + 1 >= chars.length) {
+                    throw new CredentialException("invalid process_command: trailing backslash");
+                }
+                current.append(chars[++i]);
+                continue;
+            }
+            if (c == '\'') {
+                inSingle = true;
+                continue;
+            }
+            if (c == '"') {
+                inDouble = true;
+                continue;
+            }
+            if (Character.isWhitespace(c)) {
+                if (current.length() > 0) {
+                    args.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+            current.append(c);
+        }
+
+        if (inSingle || inDouble) {
+            throw new CredentialException("invalid process_command: unclosed quote");
+        }
+        if (current.length() > 0) {
+            args.add(current.toString());
+        }
+        if (args.isEmpty() || StringUtils.isEmpty(args.get(0))) {
+            throw new CredentialException("process_command is empty");
+        }
+        return args.toArray(new String[0]);
+    }
+}

--- a/src/test/java/com/aliyun/credentials/provider/ExternalCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ExternalCredentialsProviderTest.java
@@ -33,7 +33,7 @@ public class ExternalCredentialsProviderTest {
     @Test
     public void testGetCredentialsAK() {
         ExternalCredentialsProvider provider = ExternalCredentialsProvider.builder()
-                .processCommand("/bin/echo {\"mode\":\"AK\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}")
+                .processCommand("/bin/echo '{\"mode\":\"AK\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}'")
                 .build();
 
         CredentialModel credential = provider.getCredentials();
@@ -49,7 +49,7 @@ public class ExternalCredentialsProviderTest {
         final AtomicReference<Long> capturedExpiration = new AtomicReference<>();
 
         ExternalCredentialsProvider provider = ExternalCredentialsProvider.builder()
-                .processCommand("/bin/echo {\"mode\":\"StsToken\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\",\"sts_token\":\"token\",\"expiration\":\"2049-10-20T04:27:09Z\"}")
+                .processCommand("/bin/echo '{\"mode\":\"StsToken\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\",\"sts_token\":\"token\",\"expiration\":\"2049-10-20T04:27:09Z\"}'")
                 .credentialUpdateCallback((accessKeyId, accessKeySecret, securityToken, expiration) -> {
                     capturedToken.set(securityToken);
                     capturedExpiration.set(expiration);
@@ -68,7 +68,7 @@ public class ExternalCredentialsProviderTest {
     public void testRefreshEveryCallWithoutExpiration() {
         final AtomicInteger callbackCount = new AtomicInteger(0);
         ExternalCredentialsProvider provider = ExternalCredentialsProvider.builder()
-                .processCommand("/bin/echo {\"mode\":\"AK\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}")
+                .processCommand("/bin/echo '{\"mode\":\"AK\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}'")
                 .credentialUpdateCallback((accessKeyId, accessKeySecret, securityToken, expiration) -> callbackCount.incrementAndGet())
                 .build();
 
@@ -80,7 +80,7 @@ public class ExternalCredentialsProviderTest {
     @Test
     public void testMissingFields() {
         ExternalCredentialsProvider provider = ExternalCredentialsProvider.builder()
-                .processCommand("/bin/echo {\"mode\":\"AK\",\"access_key_id\":\"ak\"}")
+                .processCommand("/bin/echo '{\"mode\":\"AK\",\"access_key_id\":\"ak\"}'")
                 .build();
 
         try {
@@ -94,7 +94,7 @@ public class ExternalCredentialsProviderTest {
     @Test
     public void testMissingStsToken() {
         ExternalCredentialsProvider provider = ExternalCredentialsProvider.builder()
-                .processCommand("/bin/echo {\"mode\":\"StsToken\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}")
+                .processCommand("/bin/echo '{\"mode\":\"StsToken\",\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}'")
                 .build();
 
         try {

--- a/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
+++ b/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
@@ -1,0 +1,96 @@
+package com.aliyun.credentials.utils;
+
+import com.aliyun.credentials.exception.CredentialException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CommandLineUtilsTest {
+
+    @Test
+    public void testSimple() {
+        Assert.assertArrayEquals(
+                new String[]{"cmd", "arg1", "arg2"},
+                CommandLineUtils.split("cmd arg1 arg2"));
+    }
+
+    @Test
+    public void testExtraWhitespace() {
+        Assert.assertArrayEquals(
+                new String[]{"cmd", "arg1", "arg2"},
+                CommandLineUtils.split("  cmd   arg1\targ2  "));
+    }
+
+    @Test
+    public void testWindowsQuotedPath() {
+        Assert.assertArrayEquals(
+                new String[]{"C:\\Program Files\\tool\\cred.exe", "get", "--profile", "default"},
+                CommandLineUtils.split("\"C:\\Program Files\\tool\\cred.exe\" get --profile default"));
+    }
+
+    @Test
+    public void testUnixSingleQuotedPath() {
+        Assert.assertArrayEquals(
+                new String[]{"/usr/local/my tools/cred", "arg"},
+                CommandLineUtils.split("'/usr/local/my tools/cred' arg"));
+    }
+
+    @Test
+    public void testQuotedArgument() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "--name", "First Last"},
+                CommandLineUtils.split("tool --name \"First Last\""));
+    }
+
+    @Test
+    public void testEscapedSpace() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "arg with space"},
+                CommandLineUtils.split("tool arg\\ with\\ space"));
+    }
+
+    @Test
+    public void testEscapedQuoteInsideDoubleQuotes() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "say \"hi\""},
+                CommandLineUtils.split("tool \"say \\\"hi\\\"\""));
+    }
+
+    @Test
+    public void testBackslashInsideDoubleQuotesLiteral() {
+        // Windows path backslashes inside double quotes stay literal
+        Assert.assertArrayEquals(
+                new String[]{"C:\\Program Files\\tool.exe"},
+                CommandLineUtils.split("\"C:\\Program Files\\tool.exe\""));
+    }
+
+    @Test(expected = CredentialException.class)
+    public void testEmpty() {
+        CommandLineUtils.split("   ");
+    }
+
+    @Test(expected = CredentialException.class)
+    public void testEmptyQuotedOnly() {
+        // "" alone yields empty argv[0]
+        CommandLineUtils.split("\"\"");
+    }
+
+    @Test
+    public void testUnclosedDoubleQuote() {
+        try {
+            CommandLineUtils.split("\"C:\\Program Files\\tool.exe");
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertTrue(e.getMessage().contains("unclosed quote"));
+        }
+    }
+
+    @Test
+    public void testTrailingBackslash() {
+        try {
+            CommandLineUtils.split("tool\\");
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertTrue(e.getMessage().contains("trailing backslash"));
+        }
+    }
+}

--- a/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
+++ b/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
@@ -24,7 +24,7 @@ public class CommandLineUtilsTest {
     public void testWindowsQuotedPath() {
         Assert.assertArrayEquals(
                 new String[]{"C:\\Program Files\\tool\\cred.exe", "get", "--profile", "default"},
-                CommandLineUtils.split("\"C:\\Program Files\\tool\\cred.exe\" get --profile default"));
+                CommandLineUtils.split("\"C:\\Program Files\\tool\\cred.exe\" get --profile default", true));
     }
 
     @Test
@@ -42,25 +42,47 @@ public class CommandLineUtilsTest {
     }
 
     @Test
-    public void testEscapedSpace() {
+    public void testEscapedSpaceUnix() {
         Assert.assertArrayEquals(
                 new String[]{"tool", "arg with space"},
-                CommandLineUtils.split("tool arg\\ with\\ space"));
+                CommandLineUtils.split("tool arg\\ with\\ space", false));
     }
 
     @Test
-    public void testEscapedQuoteInsideDoubleQuotes() {
+    public void testEscapedQuoteInsideDoubleQuotesUnix() {
         Assert.assertArrayEquals(
                 new String[]{"tool", "say \"hi\""},
-                CommandLineUtils.split("tool \"say \\\"hi\\\"\""));
+                CommandLineUtils.split("tool \"say \\\"hi\\\"\"", false));
     }
 
     @Test
-    public void testBackslashInsideDoubleQuotesLiteral() {
+    public void testSingleQuotedKeepsBackslashesUnix() {
+        // printf-style octal escapes must survive tokenizing when single quoted
+        Assert.assertArrayEquals(
+                new String[]{"/usr/bin/printf", "\\173\\042mode\\042\\175"},
+                CommandLineUtils.split("/usr/bin/printf '\\173\\042mode\\042\\175'", false));
+    }
+
+    @Test
+    public void testWindowsUnquotedPathKeepsBackslashes() {
+        Assert.assertArrayEquals(
+                new String[]{"C:\\tools\\cred.exe", "get"},
+                CommandLineUtils.split("C:\\tools\\cred.exe get", true));
+    }
+
+    @Test
+    public void testWindowsEscapedQuoteInsideDoubleQuotes() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "say \"hi\""},
+                CommandLineUtils.split("tool \"say \\\"hi\\\"\"", true));
+    }
+
+    @Test
+    public void testWindowsBackslashInsideDoubleQuotesLiteral() {
         // Windows path backslashes inside double quotes stay literal
         Assert.assertArrayEquals(
                 new String[]{"C:\\Program Files\\tool.exe"},
-                CommandLineUtils.split("\"C:\\Program Files\\tool.exe\""));
+                CommandLineUtils.split("\"C:\\Program Files\\tool.exe\"", true));
     }
 
     @Test
@@ -106,9 +128,9 @@ public class CommandLineUtilsTest {
     }
 
     @Test
-    public void testTrailingBackslash() {
+    public void testTrailingBackslashUnix() {
         try {
-            CommandLineUtils.split("tool\\");
+            CommandLineUtils.split("tool\\", false);
             Assert.fail();
         } catch (CredentialException e) {
             Assert.assertTrue(e.getMessage().contains("trailing backslash"));

--- a/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
+++ b/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
@@ -63,6 +63,27 @@ public class CommandLineUtilsTest {
                 CommandLineUtils.split("\"C:\\Program Files\\tool.exe\""));
     }
 
+    @Test
+    public void testEmptyDoubleQuotedArgument() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "", "arg"},
+                CommandLineUtils.split("tool \"\" arg"));
+    }
+
+    @Test
+    public void testEmptySingleQuotedArgument() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "", "arg"},
+                CommandLineUtils.split("tool '' arg"));
+    }
+
+    @Test
+    public void testAdjacentQuotedSegmentsFormOneArgument() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "a bc d"},
+                CommandLineUtils.split("tool \"a b\"'c d'"));
+    }
+
     @Test(expected = CredentialException.class)
     public void testEmpty() {
         CommandLineUtils.split("   ");


### PR DESCRIPTION
## Summary
- External process_command 改为支持引号的 argv 分词（POSIX shlex 语义）
- Windows 带空格路径（如 Program Files）可用双引号包成单个参数
- 补充单测并达到新增代码覆盖率门禁