### PR TITLE
fix: POSIX line-continuation in process_command splitting

### DIFF
--- a/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
+++ b/src/main/java/com/aliyun/credentials/utils/CommandLineUtils.java
@@ -11,8 +11,9 @@ import java.util.List;
  * (e.g. Windows "C:\\Program Files\\...") can be passed as a single argument.
  * <p>
  * On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
- * next char; inside double quotes, '\' only escapes '"', '\', '$', '`' and
- * newline; inside single quotes, all characters are literal.
+ * next char; inside double quotes, '\' only escapes '"', '\', '$' and '`';
+ * backslash-newline is a line continuation (both removed) outside single
+ * quotes; inside single quotes, all characters are literal.
  * <p>
  * On Windows, '\' is a path separator and is treated as a literal (except
  * '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
@@ -63,7 +64,11 @@ public final class CommandLineUtils {
                             i++;
                             continue;
                         }
-                    } else if (next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n') {
+                    } else if (next == '\n') {
+                        // Backslash-newline is a line continuation: both removed.
+                        i++;
+                        continue;
+                    } else if (next == '"' || next == '\\' || next == '$' || next == '`') {
                         current.append(next);
                         i++;
                         continue;
@@ -81,6 +86,11 @@ public final class CommandLineUtils {
                 }
                 if (i + 1 >= chars.length) {
                     throw new CredentialException("invalid process_command: trailing backslash");
+                }
+                if (chars[i + 1] == '\n') {
+                    // Backslash-newline is a line continuation: both removed.
+                    i++;
+                    continue;
                 }
                 hasToken = true;
                 current.append(chars[++i]);

--- a/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
+++ b/src/test/java/com/aliyun/credentials/utils/CommandLineUtilsTest.java
@@ -106,6 +106,20 @@ public class CommandLineUtilsTest {
                 CommandLineUtils.split("tool \"a b\"'c d'"));
     }
 
+    @Test
+    public void testBackslashNewlineOutsideQuotesIsLineContinuationUnix() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "arg1", "arg2"},
+                CommandLineUtils.split("tool arg1 \\\n arg2", false));
+    }
+
+    @Test
+    public void testBackslashNewlineInsideDoubleQuotesIsLineContinuationUnix() {
+        Assert.assertArrayEquals(
+                new String[]{"tool", "ab"},
+                CommandLineUtils.split("tool \"a\\\nb\"", false));
+    }
+
     @Test(expected = CredentialException.class)
     public void testEmpty() {
         CommandLineUtils.split("   ");


### PR DESCRIPTION
## Summary
- Treat backslash-newline as POSIX line continuation (both removed) in `CommandLineUtils.split`, outside quotes and inside double quotes, matching shlex semantics (follow-up to #104).
- Add test cases for both continuation positions.