### PR TITLE
fix: preserve transport error details for OIDC refresh

### DIFF
--- a/src/main/java/com/aliyun/credentials/http/CompatibleUrlConnClient.java
+++ b/src/main/java/com/aliyun/credentials/http/CompatibleUrlConnClient.java
@@ -60,7 +60,14 @@ public class CompatibleUrlConnClient implements Closeable {
             parseHttpConn(response, httpConn, content, null);
             return response;
         } catch (IOException e) {
+            // HTTP 4xx/5xx usually expose an error stream with status + body.
+            // Transport failures (DNS, connect/read timeout, TLS, connection refused)
+            // have no HTTP response: error stream is null and responseCode would stay 0.
             content = httpConn.getErrorStream();
+            if (content == null) {
+                String message = e.getMessage() != null ? e.getMessage() : e.toString();
+                throw new CredentialException(message, e);
+            }
             response = new HttpResponse(httpConn.getURL().toString());
             parseHttpConn(response, httpConn, content, e);
             return response;
@@ -177,14 +184,15 @@ public class CompatibleUrlConnClient implements Closeable {
     }
 
     public void parseHttpConn(HttpResponse response, HttpURLConnection httpConn, InputStream content, Exception e) {
+        if (null == content) {
+            // No response body/stream: treat as transport-layer failure.
+            String message = (e != null && e.getMessage() != null) ? e.getMessage()
+                    : (e != null ? e.toString() : "HTTP request failed without response");
+            throw new CredentialException(message, e);
+        }
         byte[] buff;
         try {
-            if (null != content) {
-                buff = readContent(content);
-            } else {
-                response.setResponseMessage(e.getMessage());
-                return;
-            }
+            buff = readContent(content);
             response.setResponseCode(httpConn.getResponseCode());
             response.setResponseMessage(httpConn.getResponseMessage());
             Map<String, List<String>> headers = httpConn.getHeaderFields();

--- a/src/main/java/com/aliyun/credentials/http/HttpResponse.java
+++ b/src/main/java/com/aliyun/credentials/http/HttpResponse.java
@@ -23,4 +23,18 @@ public class HttpResponse extends HttpMessage {
     public void setResponseMessage(String responseMessage) {
         this.responseMessage = responseMessage;
     }
+
+    /**
+     * Formats HTTP failure details for CredentialException messages.
+     * Includes status code, response message and body; never request secrets.
+     */
+    public String toHttpFailureString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("HttpCode: ").append(responseCode);
+        if (responseMessage != null && !responseMessage.isEmpty()) {
+            sb.append(", ResponseMessage: ").append(responseMessage);
+        }
+        sb.append(", result: ").append(getHttpContentString());
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/aliyun/credentials/provider/CloudSSOCredentialsProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/CloudSSOCredentialsProvider.java
@@ -85,8 +85,8 @@ public class CloudSSOCredentialsProvider extends SessionCredentialsProvider {
 
         if (httpResponse.getResponseCode() != 200) {
             throw new CredentialException(String.format(
-                    "Get session token from CloudSSO failed, HttpCode: %s, result: %s.",
-                    httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+                    "Get session token from CloudSSO failed, %s.",
+                    httpResponse.toHttpFailureString()));
         }
 
         Gson gson = new Gson();

--- a/src/main/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcher.java
+++ b/src/main/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcher.java
@@ -91,7 +91,7 @@ public class ECSMetadataServiceCredentialsFetcher {
         try {
             response = client.syncInvoke(request);
         } catch (Exception e) {
-            throw new CredentialException("Failed to connect ECS Metadata Service: " + e);
+            throw new CredentialException("Failed to connect ECS Metadata Service: " + e.getMessage(), e);
         }
 
         if (response.getResponseCode() == 404) {
@@ -99,7 +99,7 @@ public class ECSMetadataServiceCredentialsFetcher {
         }
 
         if (response.getResponseCode() != 200) {
-            throw new CredentialException(ECS_METADATA_FETCH_ERROR_MSG + " HttpCode=" + response.getResponseCode());
+            throw new CredentialException(ECS_METADATA_FETCH_ERROR_MSG + " " + response.toHttpFailureString());
         }
 
         return new String(response.getHttpContent());
@@ -182,10 +182,10 @@ public class ECSMetadataServiceCredentialsFetcher {
             try {
                 response = client.syncInvoke(request);
             } catch (Exception e) {
-                throw new CredentialException("Failed to connect ECS Metadata Service: " + e);
+                throw new CredentialException("Failed to connect ECS Metadata Service: " + e.getMessage(), e);
             }
             if (response.getResponseCode() != 200) {
-                throw new CredentialException("Failed to get token from ECS Metadata Service. HttpCode=" + response.getResponseCode() + ", ResponseMessage=" + response.getHttpContentString());
+                throw new CredentialException("Failed to get token from ECS Metadata Service. " + response.toHttpFailureString());
             }
             return new String(response.getHttpContent());
         } catch (Exception ex) {

--- a/src/main/java/com/aliyun/credentials/provider/OAuthCredentialsProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/OAuthCredentialsProvider.java
@@ -99,8 +99,8 @@ public class OAuthCredentialsProvider extends SessionCredentialsProvider {
 
         if (httpResponse.getResponseCode() != 200) {
             throw new CredentialException(String.format(
-                    "Get session token from OAuth failed, HttpCode: %s, result: %s.",
-                    httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+                    "Get session token from OAuth failed, %s.",
+                    httpResponse.toHttpFailureString()));
         }
 
         Gson gson = new Gson();
@@ -187,8 +187,8 @@ public class OAuthCredentialsProvider extends SessionCredentialsProvider {
 
         if (httpResponse.getResponseCode() != 200) {
             throw new CredentialException(String.format(
-                    "Failed to refresh OAuth token, status code: %d, result: %s.",
-                    httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+                    "Failed to refresh OAuth token, %s.",
+                    httpResponse.toHttpFailureString()));
         }
 
         Gson gson = new Gson();

--- a/src/main/java/com/aliyun/credentials/provider/OIDCRoleArnCredentialProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/OIDCRoleArnCredentialProvider.java
@@ -224,10 +224,10 @@ public class OIDCRoleArnCredentialProvider extends SessionCredentialsProvider {
         try {
             httpResponse = client.syncInvoke(httpRequest);
         } catch (Exception e) {
-            throw new CredentialException("Failed to connect OIDC Service: " + e);
+            throw new CredentialException("Failed to connect OIDC Service: " + e.getMessage(), e);
         }
         if (httpResponse.getResponseCode() != 200) {
-            throw new CredentialException(String.format("Error refreshing credentials from OIDC, HttpCode: %s, result: %s.", httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+            throw new CredentialException(String.format("Error refreshing credentials from OIDC, %s.", httpResponse.toHttpFailureString()));
         }
 
         Gson gson = new Gson();

--- a/src/main/java/com/aliyun/credentials/provider/RamRoleArnCredentialProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/RamRoleArnCredentialProvider.java
@@ -206,10 +206,10 @@ public class RamRoleArnCredentialProvider extends SessionCredentialsProvider {
         try {
             httpResponse = client.syncInvoke(httpRequest);
         } catch (Exception e) {
-            throw new CredentialException("Failed to connect RamRoleArn Service: " + e);
+            throw new CredentialException("Failed to connect RamRoleArn Service: " + e.getMessage(), e);
         }
         if (httpResponse.getResponseCode() != 200) {
-            throw new CredentialException(String.format("Error refreshing credentials from RamRoleArn, HttpCode: %s, result: %s.", httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+            throw new CredentialException(String.format("Error refreshing credentials from RamRoleArn, %s.", httpResponse.toHttpFailureString()));
         }
         Gson gson = new Gson();
         Map<String, Object> map = gson.fromJson(httpResponse.getHttpContentString(), Map.class);

--- a/src/main/java/com/aliyun/credentials/provider/RsaKeyPairCredentialProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/RsaKeyPairCredentialProvider.java
@@ -131,10 +131,10 @@ public class RsaKeyPairCredentialProvider extends SessionCredentialsProvider {
         try {
             httpResponse = client.syncInvoke(httpRequest);
         } catch (Exception e) {
-            throw new CredentialException("Failed to connect RsaKeyPair Service: " + e);
+            throw new CredentialException("Failed to connect RsaKeyPair Service: " + e.getMessage(), e);
         }
         if (httpResponse.getResponseCode() != 200) {
-            throw new CredentialException(String.format("Error refreshing credentials from RsaKeyPair, HttpCode: %s, result: %s.", httpResponse.getResponseCode(), httpResponse.getHttpContentString()));
+            throw new CredentialException(String.format("Error refreshing credentials from RsaKeyPair, %s.", httpResponse.toHttpFailureString()));
         }
         Gson gson = new Gson();
         Map<String, Object> map = gson.fromJson(httpResponse.getHttpContentString(), Map.class);

--- a/src/main/java/com/aliyun/credentials/provider/URLCredentialProvider.java
+++ b/src/main/java/com/aliyun/credentials/provider/URLCredentialProvider.java
@@ -108,8 +108,7 @@ public class URLCredentialProvider extends SessionCredentialsProvider {
 
         if (response.getResponseCode() >= 300 || response.getResponseCode() < 200) {
             throw new CredentialException("Failed to get credentials from server: " + this.credentialsURI.toString()
-                    + "\nHttpCode=" + response.getResponseCode()
-                    + "\nHttpRAWContent=" + response.getHttpContentString());
+                    + "\n" + response.toHttpFailureString());
         }
 
         Gson gson = new Gson();
@@ -118,8 +117,7 @@ public class URLCredentialProvider extends SessionCredentialsProvider {
             map = gson.fromJson(response.getHttpContentString(), Map.class);
         } catch (Exception e) {
             throw new CredentialException("Failed to get credentials from server: " + this.credentialsURI.toString()
-                    + "\nHttpCode=" + response.getResponseCode()
-                    + "\nHttpRAWContent=" + response.getHttpContentString(), e);
+                    + "\n" + response.toHttpFailureString(), e);
         }
         if (null == map || !map.containsKey("Code") || !map.get("Code").equals("Success")) {
             throw new CredentialException(String.format("Error retrieving credentials from credentialsURI result: %s.", response.getHttpContentString()));

--- a/src/test/java/com/aliyun/credentials/http/CompatibleUrlConnClientTest.java
+++ b/src/test/java/com/aliyun/credentials/http/CompatibleUrlConnClientTest.java
@@ -1,11 +1,17 @@
 package com.aliyun.credentials.http;
 
+import com.aliyun.credentials.exception.CredentialException;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -26,8 +32,17 @@ public class CompatibleUrlConnClientTest {
         httpRequest.setSysMethod(MethodType.GET);
         httpRequest.setSysConnectTimeout(1);
         httpRequest.setSysReadTimeout(1);
-        response = CompatibleUrlConnClient.compatibleGetResponse(httpRequest);
-        Assert.assertEquals("connect timed out", response.getResponseMessage().toLowerCase(Locale.ROOT));
+        try {
+            CompatibleUrlConnClient.compatibleGetResponse(httpRequest);
+            Assert.fail("transport failure should throw CredentialException");
+        } catch (CredentialException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("timed out")
+                    || e.getMessage().toLowerCase(Locale.ROOT).contains("timeout")
+                    || e.getMessage().toLowerCase(Locale.ROOT).contains("connect"));
+            Assert.assertNotNull(e.getCause());
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+        }
 
         httpRequest = new HttpRequest(null);
         try {
@@ -43,6 +58,112 @@ public class CompatibleUrlConnClientTest {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertEquals("Method is not set for HttpRequest.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void syncInvokeThrowsWhenErrorStreamIsNull() throws Exception {
+        CompatibleUrlConnClient client = spy(new CompatibleUrlConnClient());
+        HttpRequest request = new HttpRequest("https://sts.aliyuncs.com");
+        request.setSysMethod(MethodType.POST);
+        request.setSysConnectTimeout(1000);
+        request.setSysReadTimeout(1000);
+
+        HttpURLConnection conn = mock(HttpURLConnection.class);
+        doReturn(conn).when(client).buildHttpConnection(request);
+        doThrow(new ConnectException("Connection refused")).when(conn).connect();
+        when(conn.getErrorStream()).thenReturn(null);
+        when(conn.getURL()).thenReturn(new URL("https://sts.aliyuncs.com"));
+
+        try {
+            client.syncInvoke(request);
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertEquals("Connection refused", e.getMessage());
+            Assert.assertTrue(e.getCause() instanceof ConnectException);
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+        }
+        verify(conn).disconnect();
+    }
+
+    @Test
+    public void syncInvokeThrowsWhenErrorStreamNullAndMessageNull() throws Exception {
+        CompatibleUrlConnClient client = spy(new CompatibleUrlConnClient());
+        HttpRequest request = new HttpRequest("https://sts.aliyuncs.com");
+        request.setSysMethod(MethodType.GET);
+        request.setSysConnectTimeout(1000);
+        request.setSysReadTimeout(1000);
+
+        HttpURLConnection conn = mock(HttpURLConnection.class);
+        doReturn(conn).when(client).buildHttpConnection(request);
+        IOException noMessage = new IOException();
+        doThrow(noMessage).when(conn).connect();
+        when(conn.getErrorStream()).thenReturn(null);
+        when(conn.getURL()).thenReturn(new URL("https://sts.aliyuncs.com"));
+
+        try {
+            client.syncInvoke(request);
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertTrue(e.getMessage().contains("java.io.IOException"));
+            Assert.assertSame(noMessage, e.getCause());
+        }
+        verify(conn).disconnect();
+    }
+
+    @Test
+    public void syncInvokeParsesHttpErrorWhenErrorStreamPresent() throws Exception {
+        CompatibleUrlConnClient client = spy(new CompatibleUrlConnClient());
+        HttpRequest request = new HttpRequest("https://sts.aliyuncs.com");
+        request.setSysMethod(MethodType.GET);
+        request.setSysConnectTimeout(1000);
+        request.setSysReadTimeout(1000);
+
+        HttpURLConnection conn = mock(HttpURLConnection.class);
+        doReturn(conn).when(client).buildHttpConnection(request);
+        doNothing().when(conn).connect();
+        when(conn.getInputStream()).thenThrow(new IOException("Server returned HTTP response code: 400"));
+        when(conn.getErrorStream()).thenReturn(new ByteArrayInputStream("{\"Code\":\"Invalid\"}".getBytes("UTF-8")));
+        when(conn.getResponseCode()).thenReturn(400);
+        when(conn.getResponseMessage()).thenReturn("Bad Request");
+        when(conn.getURL()).thenReturn(new URL("https://sts.aliyuncs.com"));
+        Map<String, java.util.List<String>> headers = new HashMap<String, java.util.List<String>>();
+        headers.put("Content-Type", Collections.singletonList("application/json;charset=utf-8"));
+        when(conn.getHeaderFields()).thenReturn(headers);
+
+        HttpResponse response = client.syncInvoke(request);
+        Assert.assertEquals(400, response.getResponseCode());
+        Assert.assertEquals("Bad Request", response.getResponseMessage());
+        Assert.assertTrue(response.getHttpContentString().contains("Invalid"));
+        Assert.assertTrue(response.toHttpFailureString().contains("HttpCode: 400"));
+        Assert.assertTrue(response.toHttpFailureString().contains("ResponseMessage: Bad Request"));
+        verify(conn).disconnect();
+    }
+
+    @Test
+    public void parseHttpConnThrowsWhenContentNull() {
+        CompatibleUrlConnClient client = new CompatibleUrlConnClient();
+        HttpResponse response = new HttpResponse("https://example.com");
+        try {
+            client.parseHttpConn(response, mock(HttpURLConnection.class), null,
+                    new IOException("Read timed out"));
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertEquals("Read timed out", e.getMessage());
+            Assert.assertTrue(e.getCause() instanceof IOException);
+        }
+        try {
+            client.parseHttpConn(response, mock(HttpURLConnection.class), null, null);
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertEquals("HTTP request failed without response", e.getMessage());
+        }
+        try {
+            client.parseHttpConn(response, mock(HttpURLConnection.class), null, new IOException());
+            Assert.fail();
+        } catch (CredentialException e) {
+            Assert.assertTrue(e.getMessage().contains("java.io.IOException"));
+            Assert.assertTrue(e.getCause() instanceof IOException);
         }
     }
 

--- a/src/test/java/com/aliyun/credentials/http/HttpResponseTest.java
+++ b/src/test/java/com/aliyun/credentials/http/HttpResponseTest.java
@@ -4,20 +4,26 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class HttpResponseTest {
-    private HttpResponse response;
 
     @Test
-    public void httpResponseTest() {
-        response = new HttpResponse("test");
-        Assert.assertEquals("test", response.getSysUrl());
+    public void toHttpFailureStringIncludesCodeMessageAndBody() {
+        HttpResponse response = new HttpResponse("https://example.com");
+        response.setResponseCode(403);
+        response.setResponseMessage("Forbidden");
+        response.setHttpContent("{\"Message\":\"denied\"}".getBytes(), "UTF-8", FormatType.JSON);
+
+        String detail = response.toHttpFailureString();
+        Assert.assertEquals("HttpCode: 403, ResponseMessage: Forbidden, result: {\"Message\":\"denied\"}", detail);
     }
-    
+
     @Test
-    public void getSetTest() {
-        response = new HttpResponse("test");
-        response.setResponseCode(200);
-        Assert.assertEquals(200, response.getResponseCode());
-        response.setResponseMessage("OK");
-        Assert.assertEquals("OK", response.getResponseMessage());
+    public void toHttpFailureStringOmitsEmptyResponseMessage() {
+        HttpResponse response = new HttpResponse("https://example.com");
+        response.setResponseCode(500);
+        response.setResponseMessage("");
+        Assert.assertEquals("HttpCode: 500, result: ", response.toHttpFailureString());
+
+        response.setResponseMessage(null);
+        Assert.assertEquals("HttpCode: 500, result: ", response.toHttpFailureString());
     }
 }

--- a/src/test/java/com/aliyun/credentials/provider/DefaultCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/DefaultCredentialsProviderTest.java
@@ -124,7 +124,8 @@ public class DefaultCredentialsProviderTest {
             provider.getCredentials();
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertTrue(e.getMessage().contains("URLCredentialProvider: Failed to get credentials from server: http://test"));
+            Assert.assertTrue(e.getMessage().contains("URLCredentialProvider: Failed to connect Server:")
+                    || e.getMessage().contains("URLCredentialProvider: Failed to get credentials from server: http://test"));
         }
         provider.close();
 

--- a/src/test/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcherTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcherTest.java
@@ -67,7 +67,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to connect ECS Metadata Service: java.lang.RuntimeException: test",
+            Assert.assertEquals("Failed to connect ECS Metadata Service: test",
                     e.getMessage());
         }
         HttpResponse response = new HttpResponse("test");
@@ -78,7 +78,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode=500",
+            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode: 500, result: ",
                     e.getMessage());
         }
 
@@ -112,7 +112,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to connect ECS Metadata Service: java.lang.RuntimeException: test",
+            Assert.assertEquals("Failed to connect ECS Metadata Service: test",
                     e.getMessage());
         }
 
@@ -121,7 +121,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get token from ECS Metadata Service, and fallback to IMDS v1 is disabled via the disableIMDSv1 configuration is turned on. Original error: Failed to connect ECS Metadata Service: java.lang.RuntimeException: test",
+            Assert.assertEquals("Failed to get token from ECS Metadata Service, and fallback to IMDS v1 is disabled via the disableIMDSv1 configuration is turned on. Original error: Failed to connect ECS Metadata Service: test",
                     e.getMessage());
         }
 
@@ -134,7 +134,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get token from ECS Metadata Service, and fallback to IMDS v1 is disabled via the disableIMDSv1 configuration is turned on. Original error: Failed to get token from ECS Metadata Service. HttpCode=500, ResponseMessage=no token",
+            Assert.assertEquals("Failed to get token from ECS Metadata Service, and fallback to IMDS v1 is disabled via the disableIMDSv1 configuration is turned on. Original error: Failed to get token from ECS Metadata Service. HttpCode: 500, result: no token",
                     e.getMessage());
         }
 

--- a/src/test/java/com/aliyun/credentials/provider/EcsRamRoleCredentialProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/EcsRamRoleCredentialProviderTest.java
@@ -23,8 +23,10 @@ public class EcsRamRoleCredentialProviderTest {
             new EcsRamRoleCredentialProvider("");
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode=0",
-                    e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Failed to connect ECS Metadata Service:")
+                    || e.getMessage().contains("Failed to get RAM session credentials from ECS metadata service."));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode=0"));
         }
 
         EcsRamRoleCredentialProvider provider = new EcsRamRoleCredentialProvider("test");
@@ -54,8 +56,10 @@ public class EcsRamRoleCredentialProviderTest {
             new EcsRamRoleCredentialProvider(configuration);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode=0",
-                    e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Failed to connect ECS Metadata Service:")
+                    || e.getMessage().contains("Failed to get RAM session credentials from ECS metadata service."));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode=0"));
         }
 
         Config config = new Config();
@@ -86,8 +90,12 @@ public class EcsRamRoleCredentialProviderTest {
             new EcsRamRoleCredentialProvider(config);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get token from ECS Metadata Service, and fallback to IMDS v1 is disabled via the disableIMDSv1 configuration is turned on. Original error: Failed to get token from ECS Metadata Service. HttpCode=0, ResponseMessage=",
-                    e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Failed to get token from ECS Metadata Service"));
+            Assert.assertTrue(e.getMessage().contains("disableIMDSv1"));
+            Assert.assertTrue(e.getMessage().contains("Failed to connect ECS Metadata Service:")
+                    || e.getMessage().contains("Original error:"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode=0"));
         }
 
         config.disableIMDSv1 = false;
@@ -95,8 +103,10 @@ public class EcsRamRoleCredentialProviderTest {
             new EcsRamRoleCredentialProvider(config);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode=0",
-                    e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Failed to connect ECS Metadata Service:")
+                    || e.getMessage().contains("Failed to get RAM session credentials from ECS metadata service."));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode=0"));
         }
 
         AuthUtils.disableECSMetaData(true);

--- a/src/test/java/com/aliyun/credentials/provider/OAuthCredentialsProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/OAuthCredentialsProviderTest.java
@@ -205,7 +205,7 @@ public class OAuthCredentialsProviderTest {
             provider.getNewSessionCredentials(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertTrue(e.getMessage().contains("Failed to refresh OAuth token, status code: 400"));
+            Assert.assertTrue(e.getMessage().contains("Failed to refresh OAuth token, HttpCode: 400"));
         }
         provider.close();
     }

--- a/src/test/java/com/aliyun/credentials/provider/OIDCRoleArnCredentialProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/OIDCRoleArnCredentialProviderTest.java
@@ -158,6 +158,54 @@ public class OIDCRoleArnCredentialProviderTest {
     }
 
     @Test
+    public void createCredentialTransportErrorPreservesCause() {
+        Configuration config = new Configuration();
+        config.setRoleArn("test");
+        config.setOIDCProviderArn("test");
+        config.setOIDCTokenFilePath(OIDCRoleArnCredentialProviderTest.class.getClassLoader().
+                getResource("OIDCToken.txt").getPath());
+        OIDCRoleArnCredentialProvider provider = new OIDCRoleArnCredentialProvider(config);
+        CompatibleUrlConnClient client = mock(CompatibleUrlConnClient.class);
+        when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any()))
+                .thenThrow(new com.aliyun.credentials.exception.CredentialException(
+                        "Connection refused", new java.net.ConnectException("Connection refused")));
+        try {
+            provider.createCredential(client);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to connect OIDC Service: Connection refused"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+            Assert.assertFalse(e.getMessage().contains("result: ."));
+            Assert.assertNotNull(e.getCause());
+        }
+    }
+
+    @Test
+    public void createCredentialHttpErrorIncludesDetails() {
+        Configuration config = new Configuration();
+        config.setRoleArn("test");
+        config.setOIDCProviderArn("test");
+        config.setOIDCTokenFilePath(OIDCRoleArnCredentialProviderTest.class.getClassLoader().
+                getResource("OIDCToken.txt").getPath());
+        OIDCRoleArnCredentialProvider provider = new OIDCRoleArnCredentialProvider(config);
+        CompatibleUrlConnClient client = mock(CompatibleUrlConnClient.class);
+        HttpResponse response = new HttpResponse("https://sts.aliyuncs.com");
+        response.setResponseCode(400);
+        response.setResponseMessage("Bad Request");
+        response.setHttpContent("{\"Code\":\"InvalidParameter\"}".getBytes(), "UTF-8", FormatType.JSON);
+        when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any())).thenReturn(response);
+        try {
+            provider.createCredential(client);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Error refreshing credentials from OIDC"));
+            Assert.assertTrue(e.getMessage().contains("HttpCode: 400"));
+            Assert.assertTrue(e.getMessage().contains("ResponseMessage: Bad Request"));
+            Assert.assertTrue(e.getMessage().contains("InvalidParameter"));
+        }
+    }
+
+    @Test
     public void getSetTest() {
         String filePath = OIDCRoleArnCredentialProviderTest.class.getClassLoader().
                 getResource("OIDCToken.txt").getPath();

--- a/src/test/java/com/aliyun/credentials/provider/RamRoleArnCredentialProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/RamRoleArnCredentialProviderTest.java
@@ -118,6 +118,24 @@ public class RamRoleArnCredentialProviderTest {
     }
 
     @Test
+    public void createCredentialTransportErrorPreservesCause() {
+        Configuration config = new Configuration();
+        RamRoleArnCredentialProvider provider = new RamRoleArnCredentialProvider(config);
+        CompatibleUrlConnClient client = mock(CompatibleUrlConnClient.class);
+        when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any()))
+                .thenThrow(new com.aliyun.credentials.exception.CredentialException(
+                        "connect timed out", new java.net.SocketTimeoutException("connect timed out")));
+        try {
+            provider.createCredential(client);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to connect RamRoleArn Service: connect timed out"));
+            Assert.assertNotNull(e.getCause());
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+        }
+    }
+
+    @Test
     public void getSetTest() {
         RamRoleArnCredentialProvider provider = new RamRoleArnCredentialProvider(null, null, null);
         provider.setConnectTimeout(888);

--- a/src/test/java/com/aliyun/credentials/provider/RsaKeyPairCredentialProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/RsaKeyPairCredentialProviderTest.java
@@ -84,6 +84,25 @@ public class RsaKeyPairCredentialProviderTest {
     }
 
     @Test
+    public void createCredentialTransportErrorPreservesCause() {
+        String file = ProfileCredentialsProviderTest.class.getClassLoader().
+                getResource("private_key.txt").getPath();
+        RsaKeyPairCredentialProvider provider = new RsaKeyPairCredentialProvider("test", file);
+        CompatibleUrlConnClient client = mock(CompatibleUrlConnClient.class);
+        when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any()))
+                .thenThrow(new com.aliyun.credentials.exception.CredentialException(
+                        "Connection refused", new java.net.ConnectException("Connection refused")));
+        try {
+            provider.createCredential(client);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to connect RsaKeyPair Service: Connection refused"));
+            Assert.assertNotNull(e.getCause());
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
+        }
+    }
+
+    @Test
     public void getSet() {
         String file = ProfileCredentialsProviderTest.class.getClassLoader().
                 getResource("private_key.txt").getPath();

--- a/src/test/java/com/aliyun/credentials/provider/URLCredentialProviderTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/URLCredentialProviderTest.java
@@ -127,7 +127,9 @@ public class URLCredentialProviderTest {
             provider.getCredentials();
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Failed to get credentials from server: http://10.10.10.10"));
+            Assert.assertTrue(e.getMessage().contains("Failed to connect Server:")
+                    || e.getMessage().contains("Failed to get credentials from server: http://10.10.10.10"));
+            Assert.assertFalse(e.getMessage().contains("HttpCode: 0"));
         } finally {
             provider.close();
         }
@@ -141,6 +143,23 @@ public class URLCredentialProviderTest {
         when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any())).thenReturn(response);
         Assert.assertEquals(AuthConstant.CREDENTIALS_URI, provider.getNewSessionCredentials(client).value().getType());
 
+        response = new HttpResponse("test?test=test");
+        response.setResponseCode(403);
+        response.setResponseMessage("Forbidden");
+        response.setHttpContent("{\"Code\":\"Denied\"}".getBytes(), "UTF-8", FormatType.JSON);
+        when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any())).thenReturn(response);
+        try {
+            provider.getNewSessionCredentials(client);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to get credentials from server: http://10.10.10.10"));
+            Assert.assertTrue(e.getMessage().contains("HttpCode: 403"));
+            Assert.assertTrue(e.getMessage().contains("ResponseMessage: Forbidden"));
+            Assert.assertTrue(e.getMessage().contains("Denied"));
+        }
+
+        response = new HttpResponse("test?test=test");
+        response.setResponseCode(200);
         response.setHttpContent("test".getBytes(),
                 "UTF-8", FormatType.JSON);
         when(client.syncInvoke(ArgumentMatchers.<HttpRequest>any())).thenReturn(response);


### PR DESCRIPTION
## Summary
- Throw on transport failures when HttpURLConnection has no error stream instead of returning HttpCode 0
- Include response message via toHttpFailureString() for HTTP non-2xx across OIDC and related providers
- Add unit tests covering null error stream, HTTP 4xx, and provider error messages