### PR TITLE
Bump 1.0.6

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,8 @@
+2026-08-18 Version: 1.0.6
+1.fix: ECS RAM Role falls back to IMDSv1 when IMDSv2 token succeeds but later metadata requests fail.
+2.fix: treat backslash-newline as POSIX line continuation when splitting process_command.
+3.fix: preserve transport error details for OIDC credential refresh.
+
 2026-07-15 Version: 1.0.5
 1.fix: normalize CLI config path separators for Windows.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aliyun</groupId>
     <artifactId>credentials-java</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>jar</packaging>
 
     <name>credentials-java</name>

--- a/src/test/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcherTest.java
+++ b/src/test/java/com/aliyun/credentials/provider/ECSMetadataServiceCredentialsFetcherTest.java
@@ -219,7 +219,7 @@ public class ECSMetadataServiceCredentialsFetcherTest {
             fetcher.fetch(client);
             Assert.fail();
         } catch (CredentialException e) {
-            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode=500",
+            Assert.assertEquals("Failed to get RAM session credentials from ECS metadata service. HttpCode: 500, result: ",
                     e.getMessage());
         }
     }


### PR DESCRIPTION
## Summary
- Release credentials-java 1.0.6
- Changelog: ECS IMDS v2→v1 fallback, process_command line-continuation, OIDC transport error details